### PR TITLE
Feature: force safe events

### DIFF
--- a/config/felk.php
+++ b/config/felk.php
@@ -14,7 +14,20 @@ return [
 	|
 	*/
 
-	'driver'        => env('FELK_DRIVER', 'elasticsearch'),
+	'driver' => env('FELK_DRIVER', 'null_engine'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Safe Mode
+	|--------------------------------------------------------------------------
+	|
+	| This option forces felk to ignore attributes which might contain PII
+	| or other sensitive data such as the request and response while still
+	| logging other attributes.
+	|
+	*/
+
+	'force_safe'    => env('FELK_FORCE_SAFE', true),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -25,7 +38,8 @@ return [
 	|
 	*/
 	'elasticsearch' => [
-		'region' => env('AWS_ELASTICSEARCH_REGION', 'us-east-1'), // Only needed when using aws-elasticsearch provider.
+		'region' => env('AWS_ELASTICSEARCH_REGION', 'us-east-1'),
+		// Only needed when using aws-elasticsearch provider.
 		'config' => [
 			'hosts' => [
 				[
@@ -47,7 +61,11 @@ return [
 	| All environments where bib should be enabled
 	*/
 
-	'enabled_environments' => ['local', 'dev', 'staging'],
+	'enabled_environments' => [
+		'local',
+		'dev',
+		'staging',
+	],
 
 	/*
 	|--------------------------------------------------------------------------

--- a/src/Contracts/LoggableEvent.php
+++ b/src/Contracts/LoggableEvent.php
@@ -27,4 +27,11 @@ interface LoggableEvent extends Jsonable, Arrayable
 	 * @return string
 	 */
 	public function getUniqueId(): string;
+
+	/**
+	 * Get the instance as a safe array with sensitive data removed
+	 *
+	 * @return array
+	 */
+	public function toSafeArray(): array;
 }

--- a/src/Contracts/Logger.php
+++ b/src/Contracts/Logger.php
@@ -15,8 +15,9 @@ interface Logger
 	 * Log an event to the store
 	 *
 	 * @param \Fuzz\Felk\Contracts\LoggableEvent $event
+	 * @param bool                               $force_safe
 	 *
 	 * @return array
 	 */
-	public function write(LoggableEvent $event): array;
+	public function write(LoggableEvent $event, bool $force_safe = true): array;
 }

--- a/src/Engines/ElasticSearchEngine.php
+++ b/src/Engines/ElasticSearchEngine.php
@@ -68,16 +68,17 @@ class ElasticSearchEngine implements Logger
 	 * Log an event to the store
 	 *
 	 * @param \Fuzz\Felk\Contracts\LoggableEvent $event
+	 * @param bool                               $force_safe
 	 *
 	 * @return array
 	 */
-	public function write(LoggableEvent $event): array
+	public function write(LoggableEvent $event, bool $force_safe = true): array
 	{
 		$response = $this->es->index([
 			'index' => $this->index(),
 			'type'  => self::TYPE,
 			'id'    => $event->getUniqueId(),
-			'body'  => $event->toArray(),
+			'body'  => $force_safe ? $event->toSafeArray() : $event->toArray(),
 		]);
 
 		return $response;

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -47,10 +47,11 @@ class NullEngine implements Logger
 	 * Log an event to the store
 	 *
 	 * @param \Fuzz\Felk\Contracts\LoggableEvent $event
+	 * @param bool                               $force_safe
 	 *
 	 * @return array
 	 */
-	public function write(LoggableEvent $event): array
+	public function write(LoggableEvent $event, bool $force_safe = true): array
 	{
 		return [];
 	}

--- a/src/Logging/APIRequestEvent.php
+++ b/src/Logging/APIRequestEvent.php
@@ -350,4 +350,28 @@ class APIRequestEvent implements LoggableEvent
 	{
 		return is_null($this->request_id) ? hash('sha256', $this->getRoute() . round(microtime(true) * 1000)) : $this->request_id;
 	}
+
+	/**
+	 * Get the instance as a safe array with sensitive data removed
+	 *
+	 * @return array
+	 */
+	public function toSafeArray(): array
+	{
+		// We ignore the request/response to avoid having to redact potential PII
+		return [
+			'timestamp'                  => $this->getTime()->toIso8601String(),
+			'method'                     => $this->getRequest()->method(),
+			'host'                       => $this->getRequest()->getHttpHost(),
+			'route'                      => $this->getRoute(),
+			'status_code'                => $this->getStatusCode(),
+			'request_headers'            => json_encode($this->getRequestHeaders()),
+			'response_headers'           => json_encode($this->getResponseHeaders()),
+			'ip'                         => $this->getRequest()->ip(),
+			'scheme'                     => $this->getRequest()->getScheme(),
+			'port'                       => $this->getRequest()->getPort(),
+			'environment'                => getenv('APP_ENV') ?? LoggableEvent::DEFAULT_ENVIRONMENT,
+			'response_time_milliseconds' => $this->getResponseTime(),
+		];
+	}
 }

--- a/src/Middleware/FelkMiddleware.php
+++ b/src/Middleware/FelkMiddleware.php
@@ -89,7 +89,7 @@ class FelkMiddleware
 
 			$event = APIRequestEvent::factory($request, $response, $response_time_ms, time(), $request_id);
 
-			$this->logger->write($event);
+			$this->logger->write($event, $config['force_safe'] ?? true);
 
 			return true;
 		} catch (\Exception $err) {

--- a/tests/APIRequestEventTest.php
+++ b/tests/APIRequestEventTest.php
@@ -134,6 +134,67 @@ class APIRequestEventTest extends TestCase
 		putenv('APP_ENV');
 	}
 
+	public function testItSerializesToSafeArray()
+	{
+		$request  = Mockery::mock(Request::class);
+		$response = Mockery::mock(Response::class);
+		$time = time();
+
+		$request_headers = Mockery::mock(HeaderBag::class);
+		$request->headers = $request_headers;
+		$request_headers->shouldReceive('all')->once()->andReturn([
+			'req_foo' => ['bar'],
+			'req_baz' => ['bat'],
+		]);
+		$request->shouldReceive('getRequestUri')->once()->andReturn('foo/bar?baz=bat');
+
+		$response_headers = Mockery::mock(HeaderBag::class);
+		$response->headers = $response_headers;
+		$response_headers->shouldReceive('all')->once()->andReturn([
+			'res_foo' => ['bar'],
+			'res_baz' => ['bat'],
+		]);
+		$response->shouldReceive('getStatusCode')->once()->andReturn(200);
+
+		$event = APIRequestEvent::factory($request, $response, 250, $time);
+
+		$request->shouldReceive('method')->once()->andReturn('GET');
+		$request->shouldReceive('getHttpHost')->once()->andReturn('https://felk.com');
+		$request->shouldReceive('getContent')->never();
+		$request->shouldReceive('ip')->once()->andReturn('52.63.25.56');
+		$request->shouldReceive('getScheme')->once()->andReturn('https');
+		$request->shouldReceive('getPort')->once()->andReturn('80');
+		putenv('APP_ENV=some_cool_test_env');
+
+		$response->shouldReceive('getContent')->never();
+
+		$expect = [
+			'timestamp'        => Carbon::createFromTimestamp($time)->toIso8601String(),
+			'method'           => 'GET',
+			'host'             => 'https://felk.com',
+			'route'            => 'foo/bar?baz=bat',
+			'status_code'      => 200,
+			'request_headers'  => json_encode([
+				'req_foo' => ['bar'],
+				'req_baz' => ['bat'],
+			]),
+			'response_headers' => json_encode([
+				'res_foo' => ['bar'],
+				'res_baz' => ['bat'],
+			]),
+			'ip'               => '52.63.25.56',
+			'scheme'           => 'https',
+			'port'             => '80',
+			'environment'      => 'some_cool_test_env',
+			'response_time_milliseconds' => 250,
+		];
+
+		$this->assertSame($expect, $event->toSafeArray());
+
+		// Unset APP_ENV
+		putenv('APP_ENV');
+	}
+
 	public function testItSerializesToJSON()
 	{
 		$request  = Mockery::mock(Request::class);

--- a/tests/ElasticSearchEngineTest.php
+++ b/tests/ElasticSearchEngineTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 class ElasticSearchEngineTest extends TestCase
 {
-	public function testItCanWriteToLogger()
+	public function testItCanWriteToLoggerWithForceSafeOff()
 	{
 		$client = Mockery::mock(Client::class);
 
@@ -40,6 +40,84 @@ class ElasticSearchEngineTest extends TestCase
 			'environment'      => 'some_cool_test_env',
 		];
 		$event->shouldReceive('toArray')->once()->andReturn($body);
+		$event->shouldReceive('getUniqueId')->once()->andReturn('someUniqueId');
+
+		$client->shouldReceive('index')->once()->with([
+			'index' => 'fooapp_felk',
+			'type'  => 'felk_log',
+			'id'    => 'someUniqueId',
+			'body'  => $body,
+		])->andReturn(['success' => true]);
+
+		$this->assertSame(['success' => true], $logger->write($event, false));
+	}
+
+	public function testItCanWriteToLoggerWithForceSafeOn()
+	{
+		$client = Mockery::mock(Client::class);
+
+		$logger = new ElasticSearchEngine($client, 'FooApp');
+
+		$event = Mockery::mock(APIRequestEvent::class);
+		$body = [
+			'timestamp'        => time(),
+			'method'           => 'GET',
+			'host'             => 'https://felk.com',
+			'route'            => 'foo/bar?baz=bat',
+			'status_code'      => 200,
+			'request_headers'  => json_encode([
+				'req_foo' => ['bar'],
+				'req_baz' => ['bat'],
+			]),
+			'response_headers' => json_encode([
+				'res_foo' => ['bar'],
+				'res_baz' => ['bat'],
+			]),
+			'ip'               => '52.63.25.56',
+			'scheme'           => 'https',
+			'port'             => '80',
+			'environment'      => 'some_cool_test_env',
+		];
+		$event->shouldReceive('toSafeArray')->once()->andReturn($body);
+		$event->shouldReceive('getUniqueId')->once()->andReturn('someUniqueId');
+
+		$client->shouldReceive('index')->once()->with([
+			'index' => 'fooapp_felk',
+			'type'  => 'felk_log',
+			'id'    => 'someUniqueId',
+			'body'  => $body,
+		])->andReturn(['success' => true]);
+
+		$this->assertSame(['success' => true], $logger->write($event, true));
+	}
+
+	public function testItCanWriteToLoggerWithForceSafeOnByDefault()
+	{
+		$client = Mockery::mock(Client::class);
+
+		$logger = new ElasticSearchEngine($client, 'FooApp');
+
+		$event = Mockery::mock(APIRequestEvent::class);
+		$body = [
+			'timestamp'        => time(),
+			'method'           => 'GET',
+			'host'             => 'https://felk.com',
+			'route'            => 'foo/bar?baz=bat',
+			'status_code'      => 200,
+			'request_headers'  => json_encode([
+				'req_foo' => ['bar'],
+				'req_baz' => ['bat'],
+			]),
+			'response_headers' => json_encode([
+				'res_foo' => ['bar'],
+				'res_baz' => ['bat'],
+			]),
+			'ip'               => '52.63.25.56',
+			'scheme'           => 'https',
+			'port'             => '80',
+			'environment'      => 'some_cool_test_env',
+		];
+		$event->shouldReceive('toSafeArray')->once()->andReturn($body);
 		$event->shouldReceive('getUniqueId')->once()->andReturn('someUniqueId');
 
 		$client->shouldReceive('index')->once()->with([

--- a/tests/FelkMiddlewareTest.php
+++ b/tests/FelkMiddlewareTest.php
@@ -20,18 +20,22 @@ class FelkMiddlewareTest extends ApplicationTestCase
 			define('LARAVEL_START', microtime(true));
 		}
 
-		$request  = Mockery::mock(Request::class);
-		$response = Mockery::mock(Response::class);
-		$response_headers = Mockery::mock(HeaderBag::class);
+		$request           = Mockery::mock(Request::class);
+		$response          = Mockery::mock(Response::class);
+		$response_headers  = Mockery::mock(HeaderBag::class);
 		$response->headers = $response_headers;
 
 		$response_headers->shouldReceive('has')->with('X-Request-Id')->once()->andReturn(false);
 
-		$logger   = Mockery::mock(ElasticSearchEngine::class);
+		$logger = Mockery::mock(ElasticSearchEngine::class);
 
 		$middleware = new FelkMiddleware($logger);
 
-		App::shouldReceive('environment')->with(['local', 'dev', 'staging'])->once()->andReturn(false);
+		App::shouldReceive('environment')->with([
+			'local',
+			'dev',
+			'staging',
+		])->once()->andReturn(false);
 
 		$logger->shouldReceive('write')->never();
 
@@ -68,11 +72,128 @@ class FelkMiddlewareTest extends ApplicationTestCase
 
 		$middleware = new FelkMiddleware($logger);
 
-		App::shouldReceive('environment')->with(['local', 'dev', 'staging'])->once()->andReturn(true);
+		App::shouldReceive('environment')->with([
+			'local',
+			'dev',
+			'staging',
+		])->once()->andReturn(true);
 
 		$logger->shouldReceive('write')->with(Mockery::on(function ($arg) {
 			return $arg instanceof APIRequestEvent;
-		}))->once();
+		}), true)->once();
+
+		$this->assertTrue($middleware->terminate($request, $response));
+
+		putenv('APP_ENV');
+	}
+
+	public function testItWritesEventToLoggerWithForceSafeByDefault()
+	{
+		if (! defined('LARAVEL_START')) {
+			define('LARAVEL_START', microtime(true));
+		}
+
+		// Ignore force_safe
+		$this->app['config']->set('felk', [
+			'elastic_search_hosts' => ['https://felk.com:443'],
+			'enabled_environments' => [
+				'local',
+				'dev',
+				'staging',
+			],
+			'app_name'             => 'FooApp',
+		]);
+
+		$request  = Mockery::mock(Request::class);
+		$response = Mockery::mock(Response::class);
+		$logger   = Mockery::mock(ElasticSearchEngine::class);
+
+		$request_headers  = Mockery::mock(HeaderBag::class);
+		$request->headers = $request_headers;
+		$request_headers->shouldReceive('all')->once()->andReturn([
+			'req_foo' => ['bar'],
+			'req_baz' => ['bat'],
+		]);
+		$request->shouldReceive('getRequestUri')->once()->andReturn('foo/bar?baz=bat');
+		$request->shouldReceive('header')->with('User-Agent')->once()->andReturn('Some User Agent');
+
+		$response_headers  = Mockery::mock(HeaderBag::class);
+		$response->headers = $response_headers;
+		$response_headers->shouldReceive('all')->once()->andReturn([
+			'res_foo' => ['bar'],
+			'res_baz' => ['bat'],
+		]);
+		$response_headers->shouldReceive('has')->with('X-Request-Id')->once()->andReturn(false);
+		$response->shouldReceive('getStatusCode')->once()->andReturn(200);
+
+		$middleware = new FelkMiddleware($logger);
+
+		App::shouldReceive('environment')->with([
+			'local',
+			'dev',
+			'staging',
+		])->once()->andReturn(true);
+
+		$logger->shouldReceive('write')->with(Mockery::on(function ($arg) {
+			return $arg instanceof APIRequestEvent;
+		}), true)->once();
+
+		$this->assertTrue($middleware->terminate($request, $response));
+
+		putenv('APP_ENV');
+	}
+
+	public function testItWritesEventToLoggerWithForceSafeOff()
+	{
+		if (! defined('LARAVEL_START')) {
+			define('LARAVEL_START', microtime(true));
+		}
+
+		// Disable force_safe
+		$this->app['config']->set('felk', [
+			'elastic_search_hosts' => ['https://felk.com:443'],
+			'force_safe'           => false,
+			'enabled_environments' => [
+				'local',
+				'dev',
+				'staging',
+			],
+			'app_name'             => 'FooApp',
+		]);
+
+		$request  = Mockery::mock(Request::class);
+		$response = Mockery::mock(Response::class);
+		$logger   = Mockery::mock(ElasticSearchEngine::class);
+
+		$request_headers  = Mockery::mock(HeaderBag::class);
+		$request->headers = $request_headers;
+		$request_headers->shouldReceive('all')->once()->andReturn([
+			'req_foo' => ['bar'],
+			'req_baz' => ['bat'],
+		]);
+		$request->shouldReceive('getRequestUri')->once()->andReturn('foo/bar?baz=bat');
+		$request->shouldReceive('header')->with('User-Agent')->once()->andReturn('Some User Agent');
+
+		$response_headers  = Mockery::mock(HeaderBag::class);
+		$response->headers = $response_headers;
+		$response_headers->shouldReceive('all')->once()->andReturn([
+			'res_foo' => ['bar'],
+			'res_baz' => ['bat'],
+		]);
+		$response_headers->shouldReceive('has')->with('X-Request-Id')->once()->andReturn(false);
+		$response->shouldReceive('getStatusCode')->once()->andReturn(200);
+
+		$middleware = new FelkMiddleware($logger);
+
+		App::shouldReceive('environment')->with([
+			'local',
+			'dev',
+			'staging',
+		])->once()->andReturn(true);
+
+		$logger->shouldReceive('write')->with(Mockery::on(function ($arg) {
+			return $arg instanceof APIRequestEvent;
+		}), false)->once();
 
 		$this->assertTrue($middleware->terminate($request, $response));
 
@@ -110,11 +231,15 @@ class FelkMiddlewareTest extends ApplicationTestCase
 
 		$middleware = new FelkMiddleware($logger);
 
-		App::shouldReceive('environment')->with(['local', 'dev', 'staging'])->once()->andReturn(true);
+		App::shouldReceive('environment')->with([
+			'local',
+			'dev',
+			'staging',
+		])->once()->andReturn(true);
 
 		$logger->shouldReceive('write')->with(Mockery::on(function ($arg) {
 			return $arg instanceof APIRequestEvent && $arg->getRequestId() === 'fooRequestId';
-		}))->once();
+		}), true)->once();
 
 		$this->assertTrue($middleware->terminate($request, $response));
 
@@ -127,19 +252,24 @@ class FelkMiddlewareTest extends ApplicationTestCase
 			define('LARAVEL_START', microtime(true));
 		}
 
-		$request  = Mockery::mock(Request::class);
-		$response = Mockery::mock(Response::class);
-		$response_headers = Mockery::mock(HeaderBag::class);
+		$request           = Mockery::mock(Request::class);
+		$response          = Mockery::mock(Response::class);
+		$response_headers  = Mockery::mock(HeaderBag::class);
 		$response->headers = $response_headers;
 
 		$response_headers->shouldReceive('has')->with('X-Request-Id')->once()->andReturn(false);
-		$logger   = Mockery::mock(ElasticSearchEngine::class);
+		$logger = Mockery::mock(ElasticSearchEngine::class);
 
-		$request->shouldReceive('header')->with('User-Agent')->once()->andReturn(FelkMiddleware::ELB_HEALTH_CHECKER_AGENT);
+		$request->shouldReceive('header')->with('User-Agent')->once()
+				->andReturn(FelkMiddleware::ELB_HEALTH_CHECKER_AGENT);
 
 		$middleware = new FelkMiddleware($logger);
 
-		App::shouldReceive('environment')->with(['local', 'dev', 'staging'])->once()->andReturn(true);
+		App::shouldReceive('environment')->with([
+			'local',
+			'dev',
+			'staging',
+		])->once()->andReturn(true);
 
 		$this->assertFalse($middleware->terminate($request, $response));
 


### PR DESCRIPTION
By default FELK should ignore Request/Response content in order to avoid logging any potential PII or other sensitive data.

This MR adds a `toSafeArray` method on events and requires Loggers to handle a `force_safe` flag with is `true` by default. The FELK configuration is also set to default to `force_safe=true`.